### PR TITLE
Spec base class for persistent actors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,14 +23,15 @@ import com.trueaccord.scalapb.{ScalaPbPlugin => PB}
 libraryDependencies ++= Seq(
   ws,
   filters,
-  AkkaPersistence,
+  AkkaPersistenceJdbc,
   Postgres,
   LogstashEncoder,
   PlayMetrics,
   DropwizardMetrics,
-  ScalaPbRuntime    % PB.protobufConfig,
-  ScalaTestPlus     % Test,
-  Mockito           % Test
+  ScalaPbRuntime          % PB.protobufConfig,
+  ScalaTestPlus           % Test,
+  AkkaPersistenceInmemory % Test,
+  Mockito                 % Test
 )
 
 

--- a/conf/test-actors.conf
+++ b/conf/test-actors.conf
@@ -1,0 +1,13 @@
+include "application.conf"
+
+akka.persistence {
+  journal {
+    plugin = "inmemory-journal"
+    auto-start-journals = []
+  }
+
+  snapshot-store {
+    plugin = "inmemory-snapshot-store"
+    auto-start-snapshot-stores = []
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,26 +2,30 @@ import sbt._
 
 object Version {
 
-  val ScalaPb           = "0.5.38"
-  val Play              = "2.5.4"
-  val NativePackager    = "1.2.0-M5"
-  val AkkaPersistence   = "2.6.4"
-  val Postgres          = "9.4.1209"
-  val LogstashEncoder   = "4.7"
-  val ScalaTestPlus     = "1.5.1"
-  val PlayMetrics       = "2.5.13"
-  val DropwizardMetrics = "3.1.2"
-  val Mockito           = "1.10.19"
+  val ScalaPb                 = "0.5.38"
+  val Play                    = "2.5.4"
+  val NativePackager          = "1.2.0-M5"
+  val AkkaPersistenceJdbc     = "2.6.6"
+  val AkkaPersistenceInmemory = "1.3.7"
+  val Postgres                = "9.4.1209"
+  val LogstashEncoder         = "4.7"
+  val ScalaTestPlus           = "1.5.1"
+  val PlayMetrics             = "2.5.13"
+  val DropwizardMetrics       = "3.1.2"
+  val Mockito                 = "1.10.19"
 
 }
 
 object Library {
-  val AkkaPersistence   = "com.github.dnvriend"    %% "akka-persistence-jdbc"    % Version.AkkaPersistence
-  val Postgres          = "org.postgresql"         %  "postgresql"               % Version.Postgres
-  val LogstashEncoder   = "net.logstash.logback"   %  "logstash-logback-encoder" % Version.LogstashEncoder
-  val ScalaPbRuntime    = "com.trueaccord.scalapb" %% "scalapb-runtime"          % Version.ScalaPb
-  val ScalaTestPlus     = "org.scalatestplus.play" %% "scalatestplus-play"       % Version.ScalaTestPlus
-  val PlayMetrics       = "de.threedimensions"     %% "metrics-play"             % Version.PlayMetrics
-  val DropwizardMetrics =  "io.dropwizard.metrics" %  "metrics-core"             % Version.DropwizardMetrics exclude("commons-logging", "commons-logging")
-  val Mockito           = "org.mockito"            %  "mockito-core"             % Version.Mockito
+
+  val AkkaPersistenceJdbc     = "com.github.dnvriend"    %% "akka-persistence-jdbc"     % Version.AkkaPersistenceJdbc
+  val AkkaPersistenceInmemory = "com.github.dnvriend"    %% "akka-persistence-inmemory" % Version.AkkaPersistenceInmemory
+  val Postgres                = "org.postgresql"         %  "postgresql"                % Version.Postgres
+  val LogstashEncoder         = "net.logstash.logback"   %  "logstash-logback-encoder"  % Version.LogstashEncoder
+  val ScalaPbRuntime          = "com.trueaccord.scalapb" %% "scalapb-runtime"           % Version.ScalaPb
+  val ScalaTestPlus           = "org.scalatestplus.play" %% "scalatestplus-play"        % Version.ScalaTestPlus
+  val PlayMetrics             = "de.threedimensions"     %% "metrics-play"              % Version.PlayMetrics
+  val DropwizardMetrics       =  "io.dropwizard.metrics" %  "metrics-core"              % Version.DropwizardMetrics exclude("commons-logging", "commons-logging")
+  val Mockito                 = "org.mockito"            %  "mockito-core"              % Version.Mockito
+
 }

--- a/test/toguru/toggles/ActorSpec.scala
+++ b/test/toguru/toggles/ActorSpec.scala
@@ -1,0 +1,22 @@
+package toguru.toggles
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{BeforeAndAfterAll, MustMatchers}
+import org.scalatestplus.play.PlaySpec
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+
+import scala.concurrent.duration._
+
+trait ActorSpec extends PlaySpec with MustMatchers with BeforeAndAfterAll with FutureAwaits with DefaultAwaitTimeout {
+
+  implicit override def defaultAwaitTimeout = 500.millis
+
+  val config = ConfigFactory.parseResources("test-actors.conf").resolve()
+
+  implicit val system = ActorSystem("test", config)
+
+  implicit val mat = ActorMaterializer()
+
+}


### PR DESCRIPTION
- adding ActorSpec base class for persistent actor tests
- in-memory akka persistence drivers is set up in these tests
- version bump for akka persistence jdbc to 2.6.6 (using akka persistence 2.4.9)