### PR TITLE
Toggle state initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The toggle guru (Japanese for toggle).
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Contributing](#contributing)
 - [Management API](#management-api)
   - [Authentication](#authentication)
@@ -22,12 +23,16 @@ The toggle guru (Japanese for toggle).
   - [Getting Toggle Data](#getting-toggle-data)
   - [Change Toggle Rollout Percentage](#change-toggle-rollout-percentage)
   - [Disabling a Toggle](#disabling-a-toggle)
+- [Configuration](#configuration)
+  - [Togglestate Endpoint Initialization](#togglestate-endpoint-initialization)
 - [Related projects](#related-projects)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Contributing
+
+Contributions are welcome!
 
 See [contribution documentation](CONTRIBUTING.md).
 
@@ -194,6 +199,20 @@ curl example:
 curl -XDELETE https://your-endpoint.example.com/toggle/toguru-demo-toggle/globalrollout
 ```
 
+## Configuration
+
+### Togglestate Endpoint Initialization 
+
+When starting a toguru server, the toggle state endpoint will initially return
+an outdated toggle state. This is because the ToggleState actor needs to
+replay all toggle state changes before it is serving the recent toggle state.
+
+In order to prevent serving this stale state, the configuration setting
+`toggleState.initializeOnStartup` is set to `true` by default. This setting 
+also causes the health check to fail until the toggle state endpoint is fully
+initialized.
+
+To switch both behaviours off, set `toggleState.initializeOnStartup` to `false`.
 
 ## Related projects
 

--- a/app/toguru/app/Application.scala
+++ b/app/toguru/app/Application.scala
@@ -5,6 +5,7 @@ import javax.inject.{Inject, Named}
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import play.api.libs.json.Json
 import toguru.app.HealthActor.{GetHealth, HealthStatus}
 import play.api.mvc._
 
@@ -26,6 +27,8 @@ class Application @Inject() (@Named("health") healthActor: ActorRef) extends Con
       .map(toResponse(databaseUnavailableStatus))
   }
 
-  private def toResponse(databaseUnavailableStatus: Status)(health: HealthStatus): Result =
-    if (health.isDatabaseHealthy) Ok("Ok") else databaseUnavailableStatus("Database not available")
+  private def toResponse(databaseUnavailableStatus: Status)(health: HealthStatus): Result = {
+    val content = Json.obj("databaseHealthy" -> health.databaseHealthy, "toggleStateHealthy" -> health.toggleStateHealthy)
+    if (health.healthy) Ok(content) else databaseUnavailableStatus(content)
+  }
 }

--- a/app/toguru/app/Configuration.scala
+++ b/app/toguru/app/Configuration.scala
@@ -6,7 +6,7 @@ import javax.inject.{Inject, Singleton}
 
 import com.typesafe.config.{ConfigList, ConfigObject, Config => TypesafeConfig}
 import play.api.Logger
-import toguru.toggles.{AuditLog, Authentication}
+import toguru.toggles.{AuditLog, Authentication, ToggleState}
 import toguru.toggles.Authentication.ApiKey
 
 import scala.concurrent.duration._
@@ -20,6 +20,8 @@ trait Config {
   val typesafeConfig: TypesafeConfig
 
   val actorTimeout: FiniteDuration
+
+  def toggleState: ToggleState.Config
 
   def auditLog: AuditLog.Config
 }
@@ -37,6 +39,11 @@ class Configuration @Inject() (playConfig: play.api.Configuration) extends Confi
     val retentionTime   = playConfig.getMilliseconds("auditLog.retentionTime").getOrElse(90.days.toMillis).milliseconds
     val retentionLength = playConfig.getInt("auditLog.retentionLength").getOrElse(10000)
     AuditLog.Config(retentionTime, retentionLength)
+  }
+
+  override val toggleState = {
+    val initialize = playConfig.getBoolean("toggleState.initializeOnStartup").getOrElse(false)
+    ToggleState.Config(initialize)
   }
 
   override val auth = {

--- a/app/toguru/app/ToguruModule.scala
+++ b/app/toguru/app/ToguruModule.scala
@@ -9,7 +9,7 @@ import com.google.inject.{AbstractModule, Provides}
 import play.api.libs.concurrent.AkkaGuiceSupport
 import slick.backend.DatabaseConfig
 import slick.driver.JdbcDriver
-import toguru.toggles.{AuditLog, AuditLogActor, ToggleStateActor}
+import toguru.toggles.{AuditLog, AuditLogActor, ToggleState, ToggleStateActor}
 
 class ToguruModule extends AbstractModule with AkkaGuiceSupport {
 
@@ -24,6 +24,9 @@ class ToguruModule extends AbstractModule with AkkaGuiceSupport {
 
   @Provides @Singleton
   def auditLogConfig(config: Config): AuditLog.Config = config.auditLog
+
+  @Provides @Singleton
+  def toggleStateConfig(config: Config): ToggleState.Config = config.toggleState
 
   @Provides @Singleton
   def dbConfig: DatabaseConfig[JdbcDriver] = DatabaseConfig.forConfig("slick")

--- a/app/toguru/helpers/FutureTimeout.scala
+++ b/app/toguru/helpers/FutureTimeout.scala
@@ -1,0 +1,21 @@
+package toguru.helpers
+
+import java.util.concurrent.TimeoutException
+
+import akka.actor.Scheduler
+import akka.pattern.after
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+
+object FutureTimeout extends FutureTimeout {
+
+}
+
+trait FutureTimeout {
+
+  def timeout[T](deadline: FiniteDuration, future: Future[T])(implicit ec: ExecutionContext, scheduler: Scheduler) : Future[T] = {
+    val timeoutFuture = after(deadline, scheduler) { Future.failed(new TimeoutException()) }
+    Future.firstCompletedOf(List(future, timeoutFuture))
+  }
+}

--- a/app/toguru/toggles/ToggleStateActor.scala
+++ b/app/toguru/toggles/ToggleStateActor.scala
@@ -2,17 +2,42 @@ package toguru.toggles
 
 import javax.inject.Inject
 
-import akka.actor.{Actor, ActorContext, ActorRef}
+import akka.actor.{Actor, Cancellable, Scheduler}
 import ToggleStateActor._
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 import akka.persistence.query.EventEnvelope
+import slick.backend.DatabaseConfig
+import slick.driver.JdbcDriver
+import toguru.helpers.FutureTimeout.timeout
 import toguru.logging.EventPublishing
 import toguru.toggles.events._
+
+import scala.concurrent.duration._
+import scala.concurrent._
+
+object ToggleState {
+
+  case class Config(initialize: Boolean = false)
+
+}
 
 object ToggleStateActor {
   case object Shutdown
   case object GetState
+  case object ToggleStateInitializing
+  case object CheckSequenceNo
+  case class DbSequenceNo(sequenceNo: Long)
 
+  type SequenceNoProvider = (Scheduler, ExecutionContext) => Future[Long]
+
+  def dbSequenceNoProvider(dbConfig: DatabaseConfig[JdbcDriver]): SequenceNoProvider = { (scheduler: Scheduler, executionContext: ExecutionContext) =>
+    import dbConfig.driver.api._
+
+    implicit val ec = executionContext
+    implicit val s = scheduler
+
+    timeout(500.millis, dbConfig.db.run(sql"""SELECT MAX(ordering) FROM journal""".as[Long].head))
+  }
 }
 
 case class ToggleState(id: String,
@@ -21,41 +46,75 @@ case class ToggleState(id: String,
 
 case class ToggleStates(sequenceNo: Long, toggles: Seq[ToggleState])
 
-class ToggleStateActor(startHook: ActorInitializer, var toggles: Map[String, ToggleState] = Map.empty, var lastSequenceNo: Long = 0)
+class ToggleStateActor(
+                        startHook: ActorInitializer,
+                        sequenceNoProvider: SequenceNoProvider,
+                        val config: ToggleState.Config = ToggleState.Config(),
+                        var toggles: Map[String, ToggleState] = Map.empty,
+                        var lastSequenceNo: Long = 0)
   extends Actor with EventPublishing {
 
   @Inject()
-  def this(readJournal: JdbcReadJournal) = this(ToggleLog.sendToggleEvents(readJournal, Shutdown))
+  def this(readJournal: JdbcReadJournal, dbConfig: DatabaseConfig[JdbcDriver], config: ToggleState.Config) =
+    this(
+      ToggleLog.sendToggleEvents(readJournal, Shutdown),
+      dbSequenceNoProvider(dbConfig),
+      config)
+
+  var fetchDbSequenceNo: Cancellable = _
 
   override def preStart() = {
     startHook(context, self)
     publisher.event("state-actor-started")
+    implicit val ec = context.dispatcher
+    fetchDbSequenceNo = context.system.scheduler.schedule(1.seconds, 3.seconds, self, CheckSequenceNo)
   }
 
-  override def postStop() = publisher.event("state-actor-stopped")
+  override def postStop() = {
+    fetchDbSequenceNo.cancel()
+    publisher.event("state-actor-stopped")
+  }
 
-  override def receive = {
-    case GetState =>
-      publisher.event("state-actor-get-request", "togglesCount" -> toggles.values.size)
-      sender ! ToggleStates(lastSequenceNo, toggles.values.to[Vector].sortBy(_.id))
+  override def receive = if (config.initialize) initializing.orElse(global) else initialized.orElse(global)
 
-    case EventEnvelope(offset, id, _, e: ToggleEvent) =>
-      publisher.event("state-actor-toggle-event", "eventType" -> e.getClass.getSimpleName, "readJournalLatencyMs" -> latency(e.meta))
-      handleEvent(id, e)
-      lastSequenceNo = offset
+  def global: Receive = {
+    case EventEnvelope(offset, id, _, e: ToggleEvent) => handleEvent(id, e, offset)
 
     case Shutdown => context.stop(self)
   }
 
+  def initializing: Receive = {
+    case GetState => sender ! ToggleStateInitializing
+
+    case CheckSequenceNo =>
+      implicit val ec = context.dispatcher
+      sequenceNoProvider(context.system.scheduler, context.dispatcher).map(seqNo => self ! DbSequenceNo(seqNo))
+
+    case DbSequenceNo(seqNo) =>
+      if(seqNo == lastSequenceNo) {
+        fetchDbSequenceNo.cancel()
+        context.become(initialized.orElse(global))
+      }
+  }
+
+  def initialized: Receive = {
+    case GetState =>
+      sender ! ToggleStates(lastSequenceNo, toggles.values.to[Vector].sortBy(_.id))
+  }
+
   def latency(meta: Option[Metadata]): Long = meta.map(m => System.currentTimeMillis - m.time).getOrElse(0)
 
-  def handleEvent(id: String, event: ToggleEvent) = event match {
-    case ToggleCreated(_, _, tags, _) => toggles = toggles.updated(id, ToggleState(id, tags, None))
-    case ToggleUpdated(_, _, tags, _) => updateToggle(id, _.copy(tags = tags))
-    case ToggleDeleted(_)             => toggles = toggles - id
-    case GlobalRolloutCreated(p, _)   => updateToggle(id, _.copy(rolloutPercentage = Some(p)))
-    case GlobalRolloutUpdated(p, _)   => updateToggle(id, _.copy(rolloutPercentage = Some(p)))
-    case GlobalRolloutDeleted(_)      => updateToggle(id, _.copy(rolloutPercentage = None))
+  def handleEvent(id: String, event: ToggleEvent, offset: Long) = {
+    publisher.event("state-actor-toggle-event", "eventType" -> event.getClass.getSimpleName, "readJournalLatencyMs" -> latency(event.meta))
+    event match {
+      case ToggleCreated(_, _, tags, _) => toggles = toggles.updated(id, ToggleState(id, tags, None))
+      case ToggleUpdated(_, _, tags, _) => updateToggle(id, _.copy(tags = tags))
+      case ToggleDeleted(_)             => toggles = toggles - id
+      case GlobalRolloutCreated(p, _)   => updateToggle(id, _.copy(rolloutPercentage = Some(p)))
+      case GlobalRolloutUpdated(p, _)   => updateToggle(id, _.copy(rolloutPercentage = Some(p)))
+      case GlobalRolloutDeleted(_)      => updateToggle(id, _.copy(rolloutPercentage = None))
+    }
+    lastSequenceNo = offset
   }
 
   def updateToggle(id: String, update: ToggleState => ToggleState): Unit =

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -16,6 +16,10 @@ auditLog {
   retentionLength = 10000
 }
 
+toggleState {
+  initializeOnStartup = true
+}
+
 akka {
   stdout-loglevel = off // defaults to WARNING can be disabled with off. The stdout-loglevel is only in effect during system startup and shutdown
   log-dead-letters-during-shutdown = on

--- a/test/toguru/toggles/AuditLogControllerSpec.scala
+++ b/test/toguru/toggles/AuditLogControllerSpec.scala
@@ -27,6 +27,7 @@ class AuditLogControllerSpec extends PlaySpec with MockitoSugar with Authorizati
       override val typesafeConfig = mock[TypesafeConfig]
       override def auth = authConfig
       override def auditLog = AuditLog.Config()
+      override def toggleState = ToggleState.Config()
     }
 
     val system = ActorSystem()

--- a/test/toguru/toggles/ToggleControllerSpec.scala
+++ b/test/toguru/toggles/ToggleControllerSpec.scala
@@ -35,6 +35,7 @@ class ToggleControllerSpec extends PlaySpec with Results with MockitoSugar with 
       val actorTimeout: FiniteDuration = 50.millis
       override def auth = authConfig
       override def auditLog = AuditLog.Config()
+      override def toggleState = ToggleState.Config()
     }
 
     new ToggleController(config, factory)


### PR DESCRIPTION
- server waits for toggle state initialization on startup
- health check fails until initialization is completed
- behavior can be controlled with `toggleState.initializeOnStartup`
- added separate info for toggle state endpoint to health check
- initialization behavior is ultimately controlled by ToggleStateActor