### PR TITLE
Improved logging for persistence errors

### DIFF
--- a/app/toguru/logging/EventPublisher.scala
+++ b/app/toguru/logging/EventPublisher.scala
@@ -1,5 +1,7 @@
 package toguru.logging
 
+import java.sql.BatchUpdateException
+
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.{Logger, LoggerFactory}
@@ -24,11 +26,21 @@ object EventPublisher {
 
   def event(name: String, exception: Throwable, fields: (String, Any)*): Unit = {
     val eventMarkers = markers(name, fields :+ ("exception_type" -> exception.getClass.getName))
-
-    eventLogger.info(eventMarkers, exception.getMessage, exception)
+    exception match {
+      case e: BatchUpdateException => eventLogger.error(eventMarkers, nestedExeceptionAsString(e), exception)
+      case _ => eventLogger.error(eventMarkers, exception.getMessage, exception)
+    }
   }
 
   def event(e: Event): Unit = event(e.eventName, e.eventFields: _*)
+
+  def nestedExeceptionAsString(exception: BatchUpdateException): String = {
+    val exceptions = exception.getMessage
+    while(exception.getNextException != null) {
+       exceptions + "\n\n" + exception.getNextException.getMessage
+    }
+    exceptions
+  }
 
   private def markers(name: String, fields: Seq[(String, Any)]): LogstashMarker =
     appendEntries(Map(fields: _*).updated("@name", name).asJava)

--- a/test/toguru/logging/EventPublisherSpec.scala
+++ b/test/toguru/logging/EventPublisherSpec.scala
@@ -34,7 +34,7 @@ class EventPublisherSpec extends WordSpec with Matchers {
       def markers: LogstashMarker =
         Markers.appendEntries(Map("toggleId" -> "someToggle", "exception_type" -> "java.sql.BatchUpdateException", "@name" -> "testEvent").asJava)
 
-      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed\n\tSQL Exception 1\n\tSQL Exception 2\n\tSQL Exception 3", exception)
+      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed, SQL Exception 1, SQL Exception 2, SQL Exception 3", exception)
     }
 
     "not fail if no messages are contained in chained exception" in {

--- a/test/toguru/logging/EventPublisherSpec.scala
+++ b/test/toguru/logging/EventPublisherSpec.scala
@@ -31,10 +31,14 @@ class EventPublisherSpec extends WordSpec with Matchers {
 
       MockEventPublisher.event("testEvent", exception, "toggleId" -> "someToggle")
 
-      def markers: LogstashMarker =
-        Markers.appendEntries(Map("toggleId" -> "someToggle", "exception_type" -> "java.sql.BatchUpdateException", "@name" -> "testEvent").asJava)
+      val markers: LogstashMarker =
+        Markers.appendEntries(
+          Map("toggleId"          -> "someToggle",
+              "exception_type"    -> "java.sql.BatchUpdateException",
+              "@name"             -> "testEvent",
+              "nested_exceptions" -> List("SQL Exception 1", "SQL Exception 2", "SQL Exception 3")).asJava)
 
-      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed, SQL Exception 1, SQL Exception 2, SQL Exception 3", exception)
+      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed", exception)
     }
 
     "not fail if no messages are contained in chained exception" in {
@@ -43,7 +47,11 @@ class EventPublisherSpec extends WordSpec with Matchers {
       MockEventPublisher.event("testEvent", exception, "toggleId" -> "someToggle")
 
       def markers: LogstashMarker =
-        Markers.appendEntries(Map("toggleId" -> "someToggle", "exception_type" -> "java.sql.BatchUpdateException", "@name" -> "testEvent").asJava)
+        Markers.appendEntries(
+          Map("toggleId"          -> "someToggle",
+              "exception_type"    -> "java.sql.BatchUpdateException",
+              "@name"             -> "testEvent",
+              "nested_exceptions" -> List()).asJava)
 
       verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed", exception)
     }

--- a/test/toguru/logging/EventPublisherSpec.scala
+++ b/test/toguru/logging/EventPublisherSpec.scala
@@ -1,0 +1,51 @@
+package toguru.logging
+
+import java.sql.{BatchUpdateException, SQLException}
+
+import net.logstash.logback.marker.{LogstashMarker, Markers}
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import org.slf4j.Logger
+import scala.collection.JavaConverters._
+
+
+object MockEventPublisher extends Events with MockitoSugar {
+  override val eventLogger = mock[Logger]
+}
+
+class EventPublisherSpec extends WordSpec with Matchers {
+  "Event Publisher" should {
+    "handle java.sql.BatchUpdateExceptions correct" in {
+
+      val sqlException1 = new SQLException("SQL Exception 1")
+      val sqlException2 = new SQLException("SQL Exception 2")
+      val sqlException3 = new SQLException("SQL Exception 3")
+
+      val exception = new BatchUpdateException("BatchFailed", Array(3))
+
+
+      exception.setNextException(sqlException1)
+      exception.setNextException(sqlException2)
+      exception.setNextException(sqlException3)
+
+      MockEventPublisher.event("testEvent", exception, "toggleId" -> "someToggle")
+
+      def markers: LogstashMarker =
+        Markers.appendEntries(Map("toggleId" -> "someToggle", "exception_type" -> "java.sql.BatchUpdateException", "@name" -> "testEvent").asJava)
+
+      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed\n\tSQL Exception 1\n\tSQL Exception 2\n\tSQL Exception 3", exception)
+    }
+
+    "not fail if no messages are contained in chained exception" in {
+      val exception = new BatchUpdateException("BatchFailed", Array(0))
+
+      MockEventPublisher.event("testEvent", exception, "toggleId" -> "someToggle")
+
+      def markers: LogstashMarker =
+        Markers.appendEntries(Map("toggleId" -> "someToggle", "exception_type" -> "java.sql.BatchUpdateException", "@name" -> "testEvent").asJava)
+
+      verify(MockEventPublisher.eventLogger).error(markers, "BatchFailed", exception)
+    }
+  }
+}


### PR DESCRIPTION
- changed log level for events with exceptions to error. 
- BatchpdateExceptions are now logged with all chained errors in the message