### PR TITLE
Allowed to use zero percentage rollout for activations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ project/plugins/project/
 .idea
 .ivy2
 .sbt
+
+.DS_Store

--- a/app/toguru/toggles/ToggleControllerJsonCommands.scala
+++ b/app/toguru/toggles/ToggleControllerJsonCommands.scala
@@ -14,7 +14,7 @@ object ToggleControllerJsonCommands {
   }
 
   implicit val rolloutFormat: Format[Rollout] =
-    (JsPath \ "percentage").format[Int](min(1) keepAnd max(100))
+    (JsPath \ "percentage").format[Int](min(0) keepAnd max(100))
       .inmap(Rollout.apply, unlift(Rollout.unapply))
 
   implicit val activationFormat = Json.format[ToggleActivation]

--- a/test/toguru/toggles/ToggleControllerJsonCommandsSpec.scala
+++ b/test/toguru/toggles/ToggleControllerJsonCommandsSpec.scala
@@ -3,6 +3,7 @@ package toguru.toggles
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsError, Json}
 import toguru.toggles.ToggleControllerJsonCommands._
+import toguru.toggles.events.Rollout
 
 
 class ToggleControllerJsonCommandsSpec extends PlaySpec {
@@ -30,6 +31,14 @@ class ToggleControllerJsonCommandsSpec extends PlaySpec {
 
       // execute & verify
       invalidPercentage.validate[ActivationBody] mustBe a[JsError]
+    }
+
+    "accept rollout percentage of zero" in {
+      // prepare
+      val zeroPercentage = Json.obj("rollout" -> Json.obj("percentage" -> 0))
+
+      // execute & verify
+      zeroPercentage.as[ActivationBody] mustBe ActivationBody(Map.empty, Some(Rollout(0)))
     }
 
     "parse attributes with sequence value" in {

--- a/test/toguru/toggles/ToggleStateActorSpec.scala
+++ b/test/toguru/toggles/ToggleStateActorSpec.scala
@@ -62,6 +62,27 @@ class ToggleStateActorSpec extends ActorSpec with WaitFor {
       response mustBe ToggleStates(0, toggles.values.to[Seq])
     }
 
+    "filters out activations with rollout 0" in {
+      // prepare
+      val actor = createActor()
+      val id = "toggle-1"
+      val id2 = "toggle-2"
+
+      // execute
+      actor ! event(id, ToggleCreated("name", "description", Map.empty))
+      actor ! event(id, ActivationCreated(index = 0, rollout = rollout(10)))
+      actor ! event(id, ActivationUpdated(index = 0, rollout = rollout(0)))
+
+      actor ! event(id2, ToggleCreated("name", "description", Map.empty))
+      actor ! event(id2, ActivationCreated(index = 0, rollout = rollout(0)))
+
+      val response = await(actor ? GetState)
+      response mustBe ToggleStates(0, Seq(
+        ToggleState(id = id, activations = IndexedSeq.empty),
+        ToggleState(id = id2, activations = IndexedSeq.empty)
+      ))
+    }
+
     "returns correct sequence number" in {
       // prepare
       val actor = createActor()


### PR DESCRIPTION
Currently we have a problem that we can't save attributes json when setting rollout percentage as zero, because to do that, we removing activation in total.

In that PR we with @andreas-schroeder changed validation rule for rollout percentage and allowed 0 value. Also, we implemented filtering of zero percentage activations in EventsStateView, so we will not spam client part with disabled activations.